### PR TITLE
array_walk error when use environments in console

### DIFF
--- a/src/Pipeline/Environment/Manager.php
+++ b/src/Pipeline/Environment/Manager.php
@@ -43,7 +43,7 @@ class Manager
         }
         else if (is_string($environments)) {
             $environmentList = array_filter(explode(',', $environments));
-            $environmentList = array_walk($environmentList, 'trim');
+            array_walk($environmentList, 'trim');
         } else {
             $environmentList = $environments;
         }


### PR DESCRIPTION
array_walk returns a boolean, so you can store such value and treat it like an array.

To reproduce this error you've to run the command passing an environment (individual env execution) php bin/driver run pipeline single-env-name

This is the log:
04-May-2018 09:51:33 UTC] PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Driver\Pipeline\Environment\Manager::mapNamesToEnvironments() must be of the type array, boolean given, called in vendor/swiftotter/driver/src/Pipeline/Environment/Manager.php on line 59 and defined in vendor/swiftotter/driver/src/Pipeline/Environment/Manager.php:74