### PR TITLE
add {{date}} to s3 file upload

### DIFF
--- a/src/Engines/S3/Upload.php
+++ b/src/Engines/S3/Upload.php
@@ -65,7 +65,10 @@ class Upload extends Command implements CommandInterface
 
     private function getFileName(EnvironmentInterface $environment)
     {
-        return str_replace('{{environment}}', '-' . $environment->getName(), $this->getFileKey());
+        $replace = str_replace('{{environment}}', '-' . $environment->getName(), $this->getFileKey());
+        $replace = str_replace('{{date}}', date('YmdHis'), $replace);
+
+        return $replace;
     }
 
     private function getFileKey()


### PR DESCRIPTION
We needed this functionality in our system so I just make a PR to see if that make sense or is useful for you!

Add the possibility of inserting the actual date (YmdHis) into the file when uploading it to S3. Of this way you don't override the dump every time you upload it to s3.

Example:
```yaml
  s3:
    engine: s3
    compressed-file-key: "{{date}}-sample{{environment}}.gz"
    uncompressed-file-key: "{{date}}-sample{{environment}}.sql"
```
Regards!