### PR TITLE
add dump-path option for sandbox export path

### DIFF
--- a/src/Engines/MySql/Sandbox/Export.php
+++ b/src/Engines/MySql/Sandbox/Export.php
@@ -136,8 +136,12 @@ class Export extends Command implements CommandInterface, CleanupInterface
     private function getFilename($environmentName)
     {
         if (!$this->filename) {
+            $path = $this->configuration->getNode('connections/rds/dump-path');
+            if (!$path) {
+                $path ='/tmp';
+            }
             do {
-                $file = '/tmp/driver_tmp_' . $environmentName . '_' . $this->random->getRandomString(10) . ($this->compressOutput() ? '.gz' : '.sql');
+                $file = $path . '/driver_tmp_' . $environmentName . '_' . $this->random->getRandomString(10) . ($this->compressOutput() ? '.gz' : '.sql');
             } while (file_exists($file));
 
             $this->filename = $file;


### PR DESCRIPTION
This is another functionality we needed for our system, so again I make a PR to see if it's also useful for you!
We had some problems trying to export dump to /tmp folder.
This work was made by @AntonioAPG

## Resume
This PR allows us to add `dump-path` to the rds yaml node (sandbox). This will modify the path where the application saves the dump file.
Example:
```yaml
  rds:
    key: ....
    dump-path: /custom/path
```