### PR TITLE
Update guzzle requirement to allow ^6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "symfony/console": ">=2.6",
         "symfony/event-dispatcher": ">=2.5",
         "ericpoe/haystack": "^1.0",
-        "guzzlehttp/guzzle": "^7.3",
+        "guzzlehttp/guzzle": "^6.5 || ^7.3",
         "psr/log": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This fixes a problem on GSG where guzzle is 6.5.5