### PR TITLE
Revert to a previous version of Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "symfony/console": ">=2.6",
         "symfony/event-dispatcher": ">=2.5",
         "ericpoe/haystack": "^1.0",
-        "guzzlehttp/guzzle": "^7.3",
+        "guzzlehttp/guzzle": "^6.2",
         "psr/log": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This should help provide more widespread compatibility. I could not locate any changes that would require Guzzle v7.