### PR TITLE
#20 - php-di and guzzle updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "A database production to sandbox utility to sanitize data.",
     "type": "library",
     "require": {
-        "php-di/php-di": "^5.4",
+        "php-di/php-di": "^6.0",
         "aws/aws-sdk-php": "^3.19",
         "symfony/yaml": ">=2.3",
         "ericpoe/haystack": "^1.0",
-        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/guzzle": "^6.2|^7.0",
         "psr/log": "^1.0",
         "symfony/console": "^4.4",
         "symfony/event-dispatcher": "^4.0"


### PR DESCRIPTION
- php-di and guzzle updates were needed for Magento 2.4.4
- I checked that after these changes Driver can be installed with Composer on Magento 2.4.4 and 2.3.7-p3