### PR TITLE
#57: Fix for "Unable to fork" issue when executing a lot of mysqldump commands

### DIFF
--- a/src/Engines/MySql/Export/CommandAssembler.php
+++ b/src/Engines/MySql/Export/CommandAssembler.php
@@ -20,11 +20,14 @@ class CommandAssembler
         $this->tablesProvider = $tablesProvider;
     }
 
+    /**
+     * @return string[]
+     */
     public function execute(
         ConnectionInterface $connection,
         EnvironmentInterface $environment,
         string $dumpFile
-    ): string {
+    ): array {
         $ignoredTables = $this->tablesProvider->getIgnoredTables($environment);
         $emptyTables = $this->tablesProvider->getEmptyTables($environment);
         foreach ($this->tablesProvider->getAllTables($connection) as $table) {
@@ -37,7 +40,7 @@ class CommandAssembler
             $commands[] = $this->getSingleCommand($connection, $emptyTables, $dumpFile, false);
         }
         if (empty($commands)) {
-            return '';
+            return [];
         }
         array_unshift(
             $commands,
@@ -47,7 +50,7 @@ class CommandAssembler
         $commands[] = "echo '/*!40014 SET FOREIGN_KEY_CHECKS=@ORG_FOREIGN_KEY_CHECKS */;' >> $dumpFile";
         $commands[] = "cat $dumpFile | "
             . "sed -E 's/DEFINER[ ]*=[ ]*`[^`]+`@`[^`]+`/DEFINER=CURRENT_USER/g' | gzip > $dumpFile.gz";
-        return implode(';', $commands);
+        return $commands;
     }
 
     /**


### PR DESCRIPTION
Instead of running all commands at once, they now run one after each other.