### PR TITLE
#56 & #61 - Dump refactored

### DIFF
--- a/.driver/environments.yaml.dist
+++ b/.driver/environments.yaml.dist
@@ -10,5 +10,7 @@ environments:
           # For example, if your `TABLE_NAME` is `core_config_data`, Driver will search for a table in the database that
           # ends with `core_config_data`. Thus, `core_config_data` and `sample_core_config_data` would all match.
     ignored_tables: # OPTIONAL, tables listed here will be ignored in the final dump with:
-                    # mysqldump ... --ignored-tables=DATABASE.table_1
+                    # mysqldump ... --ignored-tables=TABLE_NAME
+      - TABLE_NAME
+    empty_tables: # OPTIONAL, tables listed here will be dumped without data
       - TABLE_NAME

--- a/.driver/environments.yaml.example
+++ b/.driver/environments.yaml.example
@@ -29,48 +29,7 @@ environments:
         - "UPDATE {{table_name}} SET value = 'store.local' WHERE path LIKE 'web/cookie/cookie_domain' AND scope_id = 0;"
         - "UPDATE {{table_name}} SET value = 'localhost' WHERE path LIKE 'catalog/search/elasticsearch%_server_hostname' AND scope_id = 0;"
     ignored_tables:
-      - setup_module
-      - customer_address_entity
-      - customer_address_entity_datetime
-      - customer_address_entity_decimal
-      - customer_address_entity_int
-      - customer_address_entity_text
-      - customer_address_entity_varchar
-      - customer_entity
-      - customer_entity_datetime
-      - customer_entity_decimal
-      - customer_entity_int
-      - customer_entity_text
-      - customer_entity_varchar
-      - sales_creditmemo
-      - sales_credimemo_comment
-      - sales_creditmemo_grid
-      - sales_creditmemo_item
-      - sales_invoice
-      - sales_invoice_comment
-      - sales_invoice_grid
-      - sales_invoice_item
-      - sales_order
-      - sales_order_address
-      - sales_order_grid
-      - sales_order_item
-      - sales_order_payment
-      - sales_order_status_history
-      - sales_shipment
-      - sales_shipment_comment
-      - sales_shipment_grid
-      - sales_shipment_item
-      - sales_shipment_track
-      - sales_invoiced_aggregated
-      - sales_invoiced_aggregated_order
-      - sales_payment_transaction
-      - sales_order_aggregated_created
-      - sales_order_tax
-      - sales_order_tax_item
-      - sales_quote
-      - sales_quote_address
-      - sales_quote_address_item
-      - sales_quote_item
-      - sales_quote_item_option
-      - sales_quote_payment
-      - sales_quote_shipping_rate
+      - some_non_magento_table
+    empty_tables:
+      - customer_log
+      - customer_visitor

--- a/src/Engines/MySql/Export/CommandAssembler.php
+++ b/src/Engines/MySql/Export/CommandAssembler.php
@@ -7,6 +7,7 @@ namespace Driver\Engines\MySql\Export;
 use Driver\Engines\ConnectionInterface;
 use Driver\Pipeline\Environment\EnvironmentInterface;
 
+use function array_diff;
 use function array_unshift;
 use function implode;
 use function in_array;
@@ -26,28 +27,29 @@ class CommandAssembler
     public function execute(
         ConnectionInterface $connection,
         EnvironmentInterface $environment,
-        string $dumpFile
+        string $dumpFile,
+        string $triggersDumpFile
     ): array {
+        $allTables = $this->tablesProvider->getAllTables($connection);
         $ignoredTables = $this->tablesProvider->getIgnoredTables($environment);
+        if (array_diff($allTables, $ignoredTables) === []) {
+            return [];
+        }
         $emptyTables = $this->tablesProvider->getEmptyTables($environment);
         $commands = [$this->getStructureCommand($connection, $ignoredTables, $dumpFile)];
-        foreach ($this->tablesProvider->getAllTables($connection) as $table) {
+        foreach ($allTables as $table) {
             if (in_array($table, $ignoredTables) || in_array($table, $emptyTables)) {
                 continue;
             }
             $commands[] = $this->getDataCommand($connection, [$table], $dumpFile);
         }
-        if (empty($commands)) {
-            return [];
-        }
         array_unshift(
             $commands,
             "echo '/*!40014 SET @ORG_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;'"
-            . ">> $dumpFile"
+            . " | gzip >> $dumpFile"
         );
-        $commands[] = "echo '/*!40014 SET FOREIGN_KEY_CHECKS=@ORG_FOREIGN_KEY_CHECKS */;' >> $dumpFile";
-        $commands[] = "cat $dumpFile | "
-            . "sed -E 's/DEFINER[ ]*=[ ]*`[^`]+`@`[^`]+`/DEFINER=CURRENT_USER/g' | gzip > $dumpFile.gz";
+        $commands[] = "echo '/*!40014 SET FOREIGN_KEY_CHECKS=@ORG_FOREIGN_KEY_CHECKS */;' | gzip >> $dumpFile";
+        $commands[] = $this->getTriggersCommand($connection, $ignoredTables, $triggersDumpFile);
         return $commands;
     }
 
@@ -65,12 +67,15 @@ class CommandAssembler
             "--single-transaction",
             "--no-tablespaces",
             "--no-data",
+            "--skip-triggers",
             "--host={$connection->getHost()}",
             $connection->getDatabase()
         ];
         foreach ($ignoredTables as $table) {
             $parts[] = "--ignore-table={$connection->getDatabase()}.{$table}";
         }
+        $parts[] = "| sed -E 's/DEFINER[ ]*=[ ]*`[^`]+`@`[^`]+`/DEFINER=CURRENT_USER/g'";
+        $parts[] = "| gzip";
         $parts[] = ">> $dumpFile";
         return implode(' ', $parts);
     }
@@ -86,10 +91,37 @@ class CommandAssembler
             "--single-transaction",
             "--no-tablespaces",
             "--no-create-info",
+            "--skip-triggers",
             "--host={$connection->getHost()}",
             $connection->getDatabase(),
             implode(' ', $tables)
         ];
+        $parts[] = "| gzip";
+        $parts[] = ">> $dumpFile";
+        return implode(' ', $parts);
+    }
+
+    /**
+     * @param string[] $ignoredTables
+     */
+    private function getTriggersCommand(ConnectionInterface $connection, array $ignoredTables, string $dumpFile): string
+    {
+        $parts = [
+            "mysqldump --user=\"{$connection->getUser()}\"",
+            "--password=\"{$connection->getPassword()}\"",
+            "--single-transaction",
+            "--no-tablespaces",
+            "--no-data",
+            "--no-create-info",
+            "--triggers",
+            "--host={$connection->getHost()}",
+            $connection->getDatabase()
+        ];
+        foreach ($ignoredTables as $table) {
+            $parts[] = "--ignore-table={$connection->getDatabase()}.{$table}";
+        }
+        $parts[] = "| sed -E 's/DEFINER[ ]*=[ ]*`[^`]+`@`[^`]+`/DEFINER=CURRENT_USER/g'";
+        $parts[] = "| gzip";
         $parts[] = ">> $dumpFile";
         return implode(' ', $parts);
     }

--- a/src/Engines/MySql/Sandbox/Import.php
+++ b/src/Engines/MySql/Sandbox/Import.php
@@ -74,14 +74,13 @@ class Import extends Command implements CommandInterface
     public function assembleCommand(string $path): string
     {
         $command = implode(' ', [
+            "gunzip < $path |",
             "mysql --user={$this->remoteConnection->getUser()}",
-                "--password={$this->remoteConnection->getPassword()}",
-                "--host={$this->remoteConnection->getHost()}",
-                "--port={$this->remoteConnection->getPort()}",
-                $this->remoteConnection->useSsl() ? "--ssl-ca={$this->ssl->getPath()}" : "",
-                "{$this->remoteConnection->getDatabase()}",
-            "<",
-            $path
+            "--password={$this->remoteConnection->getPassword()}",
+            "--host={$this->remoteConnection->getHost()}",
+            "--port={$this->remoteConnection->getPort()}",
+            $this->remoteConnection->useSsl() ? "--ssl-ca={$this->ssl->getPath()}" : "",
+            "{$this->remoteConnection->getDatabase()}"
         ]);
 
         if (

--- a/src/Engines/MySql/Transformation.php
+++ b/src/Engines/MySql/Transformation.php
@@ -78,10 +78,7 @@ class Transformation extends Command implements CommandInterface
                     $ex->getMessage(),
                     $ex->getTraceAsString()
                 ]);
-                $this->output->writeln("<error>Query transformation failed: " . $query, [
-                    $ex->getMessage(),
-                    $ex->getTraceAsString()
-                ] . '</error>');
+                $this->output->writeln("<error>Query transformation failed: " . $query . '</error>');
             }
         });
     }


### PR DESCRIPTION
The initial dump was refactored, so it first dumps database structure and then its data. This prevents error reported in #56. Also, triggers were excluded from RDS processing, because of issue reported in #61. Right now triggers are dumped to separate file which is later concatenated with the file produced by RDS.