### PR TITLE
Upping symfony/console dependency to ^5.4 to be compatible with 2.4.6 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0",
         "php-di/php-di": "^6.0",
         "psr/log": "^1.0",
-        "symfony/console": "^4.4",
+        "symfony/console": "^5.4",
         "symfony/event-dispatcher": "^4.0",
         "symfony/yaml": ">=2.3"
     },


### PR DESCRIPTION
@michalbiarda, this dependency was stopping me from upgrading to 2.4.6. Is there anything I need to do before this gets merged?